### PR TITLE
upgrade Railsのバージョンを5.2.6に更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 ruby '2.5.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.4', '>= 5.2.4.5'
+gem 'rails', '~> 5.2.6'
 # Use mysql as the database for Active Record
 gem 'mysql2', '>= 0.3.18', '< 0.6.0'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ DEPENDENCIES
   mini_racer
   mysql2 (>= 0.3.18, < 0.6.0)
   puma (~> 3.0)
-  rails (~> 5.2.4, >= 5.2.4.5)
+  rails (~> 5.2.6)
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
## リンク
- Issues
  - #14 
  - Close #18

- 参考
  - [【初心者向け】form_withでundefined method `form_with' forというエラーが出た際の対応方法について - Qiita](https://qiita.com/pontarou194/items/d0ecbbc2933620377a65)

## 内容
`5.2.4.5`へ更新しようとしたら`5.2.6`になっていたのでGemfileの中身を`5.2.6`に変更