### PR TITLE
ステップ11: バリデーションを設定してみよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
 
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 5.0.1'
   gem 'spring-commands-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,11 @@ GEM
     diff-lcs (1.4.4)
     erubi (1.10.0)
     execjs (2.8.0)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -230,6 +235,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  factory_bot_rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 | ----------- | ------------- | ---- | --- | ------- | -------------- |
 | id          | BIGINT(20)    | NO   | PRI | NULL    | AUTO_INCREMENT |
 | user_id     | VARCHAR(20)   | NO   |     | NULL    |                |
-| title       | VARCHAR(100)  | NO   |     | NULL    |                |
+| title       | VARCHAR(100)  | NO   |     | タスク   |                |
 | description | VARCHAR(1000) | YES  |     | NULL    |                |
-| status      | VARCHAR(10)   | YES  |     | NULL    |                |
+| status      | VARCHAR(10)   | NO   |     | 未着手   |                |
 | priority    | VARCHAR(10)   | YES  |     | NULL    |                |
 | deadline    | DATETIME      | YES  |     | NULL    |                |
 | created_at  | TIMESTAMP     | NO   |     | NULL    |                |

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,7 +15,7 @@ class TasksController < ApplicationController
       redirect_to root_path, notice: '新しいタスクを作成しました'
     else
       flash.now[:alert] = 'タスクの作成ができませんでした'
-      render :new
+      render new_task_path
     end
   end
 
@@ -33,7 +33,7 @@ class TasksController < ApplicationController
       redirect_to task_path(@task.id), notice: 'タスクを更新しました'
     else
       flash.now[:alert] = 'タスクの更新ができませんでした'
-      render task_path(@task.id)
+      render :new
     end
   end
 
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
       redirect_to root_path, notice: 'タスクを削除しました'
     else
       flash.now[:alert] = 'タスクの削除ができませんでした'
-      render task_path(@task.id)
+      render :edit
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,6 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 1000 }
-  validates :status, presence: true, length: { maximum: 10 }
-  validates :priority, length: { maximum: 10 }
+  validates :status, presence: true, length: { maximum: 10 }, inclusion: { in: %w[未着手 進行中 完了] }
+  validates :priority, length: { maximum: 10 }, inclusion: { in: ['高', '中', '低', '', nil] }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,5 @@
 
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
+  validates :description, length: { maximum: 1000 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  validates :title, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 100 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,5 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 1000 }
+  validates :status, presence: true, length: { maximum: 10 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,4 +4,5 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 1000 }
   validates :status, presence: true, length: { maximum: 10 }
+  validates :priority, length: { maximum: 10 }
 end

--- a/db/migrate/20210524021902_change_not_null_constraint_to_tasks.rb
+++ b/db/migrate/20210524021902_change_not_null_constraint_to_tasks.rb
@@ -1,0 +1,11 @@
+class ChangeNotNullConstraintToTasks < ActiveRecord::Migration[5.2]
+  def up
+    change_column :tasks, :title, :string, :limit => 100, null:false, default: 'タスク'
+    change_column :tasks, :status, :string, :limit => 10, null:false, default: '未着手'
+  end
+
+  def down
+    change_column :tasks, :title, :string, :limit => 100, null:false, default: false
+    change_column :tasks, :status, :string, :limit => 10, null:true, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210506023552) do
+ActiveRecord::Schema.define(version: 2021_05_24_021902) do
 
-  create_table "tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "title",       limit: 100,  null: false
-    t.string   "description", limit: 1000
-    t.string   "status",      limit: 10
-    t.string   "priority",    limit: 10
+  create_table "tasks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title", limit: 100, default: "タスク", null: false
+    t.string "description", limit: 1000
+    t.string "status", limit: 10, default: "未着手", null: false
+    t.string "priority", limit: 10
     t.datetime "deadline"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :task do
+    title { 'タスク' }
+    status { '未着手' }
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Task, type: :model do
       let(:title) { 'A' * 101 }
       it '無効' do
         expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array('Title is too long (maximum is 100 characters)')
+        expect(task.errors.full_messages).to contain_exactly('Title is too long (maximum is 100 characters)')
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe Task, type: :model do
       let(:title) { 'A' * 0 }
       it '無効' do
         expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array("Title can't be blank")
+        expect(task.errors.full_messages).to contain_exactly("Title can't be blank")
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe Task, type: :model do
       let(:description) { 'A' * 1001 }
       it '無効' do
         expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array('Description is too long (maximum is 1000 characters)')
+        expect(task.errors.full_messages).to contain_exactly('Description is too long (maximum is 1000 characters)')
       end
     end
 
@@ -59,26 +59,46 @@ RSpec.describe Task, type: :model do
   describe '`status`のバリデーションをテスト' do
     let(:task) { build(:task, status: status) }
 
-    context '`status`が10文字の場合' do
-      let(:status) { 'A' * 10 }
+    context '`status`が未着手の場合' do
+      let(:status) { '未着手' }
       it '有効' do
         expect(task).to be_valid
       end
     end
 
-    context '`status`が11文字の場合' do
-      let(:status) { 'A' * 11 }
-      it '無効' do
-        expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array('Status is too long (maximum is 10 characters)')
+    context '`status`が進行中の場合' do
+      let(:status) { '進行中' }
+      it '有効' do
+        expect(task).to be_valid
       end
     end
 
-    context '`status`が0文字の場合' do
-      let(:status) { 'A' * 0 }
+    context '`status`が完了の場合' do
+      let(:status) { '完了' }
+      it '有効' do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`status`が関係ない文字の場合' do
+      let(:status) { 'A' * 20 }
       it '無効' do
         expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array("Status can't be blank")
+        expect(task.errors.full_messages).to contain_exactly(
+          'Status is not included in the list',
+          'Status is too long (maximum is 10 characters)'
+        )
+      end
+    end
+
+    context '`status`が空文字の場合' do
+      let(:status) { '' }
+      it '無効' do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to contain_exactly(
+          "Status can't be blank",
+          'Status is not included in the list'
+        )
       end
     end
   end
@@ -86,25 +106,35 @@ RSpec.describe Task, type: :model do
   describe '`priority`のバリデーションをテスト' do
     let(:task) { build(:task, priority: priority) }
 
-    context '`priority`が10文字の場合' do
-      let(:priority) { 'A' * 10 }
+    context '`priority`が高の場合' do
+      let(:priority) { '高' }
       it '有効' do
         expect(task).to be_valid
       end
     end
 
-    context '`priority`が11文字の場合' do
-      let(:priority) { 'A' * 11 }
+    context '`priority`が中の場合' do
+      let(:priority) { '中' }
+      it '有効' do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`priority`が低の場合' do
+      let(:priority) { '低' }
+      it '有効' do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`priority`が関係ない文字の場合' do
+      let(:priority) { 'A' * 20 }
       it '無効' do
         expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array('Priority is too long (maximum is 10 characters)')
-      end
-    end
-
-    context '`priority`が0文字の場合' do
-      let(:priority) { 'A' * 0 }
-      it '有効' do
-        expect(task).to be_valid
+        expect(task.errors.full_messages).to contain_exactly(
+          'Priority is not included in the list',
+          'Priority is too long (maximum is 10 characters)'
+        )
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -28,37 +28,48 @@ RSpec.describe Task, type: :model do
         expect(task.errors.full_messages).to match_array("Title can't be blank")
       end
     end
+  end
 
-    context '`title`が空白のみの場合、無効' do
-      let(:title) { '' }
+  describe '`description`のバリデーションをテスト' do
+    let(:task) { build(:task, description: description) }
+
+    context '`description`が1000文字の場合、有効' do
+      let(:description) { 'A' * 1000 }
+      it do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`description`が1001文字の場合、無効' do
+      let(:description) { 'A' * 1001 }
       it do
         expect(task).to_not be_valid
-        expect(task.errors.full_messages).to match_array("Title can't be blank")
+        expect(task.errors.full_messages).to match_array('Description is too long (maximum is 1000 characters)')
+      end
+    end
+
+    context '`description`が0文字の場合、有効' do
+      let(:description) { 'A' * 0 }
+      it do
+        expect(task).to be_valid
       end
     end
   end
 
-  describe '`description`のバリデーションをテスト' do
-    it '`description`が1000文字の場合、有効'
-    it '`description`が1001文字の場合、無効'
-    it '`description`が0文字の場合、有効'
-  end
-
   describe '`status`のバリデーションをテスト' do
-    it '`status`が10文字の場合、有効'
-    it '`status`が11文字の場合、無効'
-    it '`status`が0文字の場合、無効'
-    it '`status`が空白のみの場合、無効'
+    context '`status`が10文字の場合、有効'
+    context '`status`が11文字の場合、無効'
+    context '`status`が0文字の場合、無効'
   end
 
   describe '`priority`のバリデーションをテスト' do
-    it '`priority`が10文字の場合、有効'
-    it '`priority`が11文字の場合、無効'
-    it '`priority`が0文字の場合、有効'
+    context '`priority`が10文字の場合、有効'
+    context '`priority`が11文字の場合、無効'
+    context '`priority`が0文字の場合、有効'
   end
 
   describe '`deadline`のバリデーションをテスト' do
-    it '`deadline`が`2023-01-01 17:28:00 UT`の場合、有効'
-    it '`deadline`が`2023-01-01 17:28:00 UT`でない場合、無効'
+    context '`deadline`が`2023-01-01 17:28:00 UT`の場合、有効'
+    context '`deadline`が`2023-01-01 17:28:00 UT`でない場合、無効'
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Task, type: :model do
       end
     end
 
-    context '`status`が0文字の場合、有効' do
+    context '`status`が0文字の場合、無効' do
       let(:status) { 'A' * 0 }
       it do
         expect(task).to_not be_valid
@@ -84,9 +84,29 @@ RSpec.describe Task, type: :model do
   end
 
   describe '`priority`のバリデーションをテスト' do
-    context '`priority`が10文字の場合、有効'
-    context '`priority`が11文字の場合、無効'
-    context '`priority`が0文字の場合、有効'
+    let(:task) { build(:task, priority: priority) }
+
+    context '`priority`が10文字の場合、有効' do
+      let(:priority) { 'A' * 10 }
+      it do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`priority`が11文字の場合、無効' do
+      let(:priority) { 'A' * 11 }
+      it do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array('Priority is too long (maximum is 10 characters)')
+      end
+    end
+
+    context '`priority`が0文字の場合、有効' do
+      let(:priority) { 'A' * 0 }
+      it do
+        expect(task).to be_valid
+      end
+    end
   end
 
   describe '`deadline`のバリデーションをテスト' do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,5 +3,62 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '`title`のバリデーションをテスト' do
+    let(:task) { build(:task, title: title) }
+
+    context '`title`が100文字の場合、有効' do
+      let(:title) { 'A' * 100 }
+      it do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`title`が101文字の場合、無効' do
+      let(:title) { 'A' * 101 }
+      it do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array('Title is too long (maximum is 100 characters)')
+      end
+    end
+
+    context '`title`が0文字の場合、無効' do
+      let(:title) { 'A' * 0 }
+      it do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array("Title can't be blank")
+      end
+    end
+
+    context '`title`が空白のみの場合、無効' do
+      let(:title) { '' }
+      it do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array("Title can't be blank")
+      end
+    end
+  end
+
+  describe '`description`のバリデーションをテスト' do
+    it '`description`が1000文字の場合、有効'
+    it '`description`が1001文字の場合、無効'
+    it '`description`が0文字の場合、有効'
+  end
+
+  describe '`status`のバリデーションをテスト' do
+    it '`status`が10文字の場合、有効'
+    it '`status`が11文字の場合、無効'
+    it '`status`が0文字の場合、無効'
+    it '`status`が空白のみの場合、無効'
+  end
+
+  describe '`priority`のバリデーションをテスト' do
+    it '`priority`が10文字の場合、有効'
+    it '`priority`が11文字の場合、無効'
+    it '`priority`が0文字の場合、有効'
+  end
+
+  describe '`deadline`のバリデーションをテスト' do
+    it '`deadline`が`2023-01-01 17:28:00 UT`の場合、有効'
+    it '`deadline`が`2023-01-01 17:28:00 UT`でない場合、無効'
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe Task, type: :model do
   describe '`title`のバリデーションをテスト' do
     let(:task) { build(:task, title: title) }
 
-    context '`title`が100文字の場合、有効' do
+    context '`title`が100文字の場合' do
       let(:title) { 'A' * 100 }
-      it do
+      it '有効' do
         expect(task).to be_valid
       end
     end
 
-    context '`title`が101文字の場合、無効' do
+    context '`title`が101文字の場合' do
       let(:title) { 'A' * 101 }
-      it do
+      it '無効' do
         expect(task).to_not be_valid
         expect(task.errors.full_messages).to match_array('Title is too long (maximum is 100 characters)')
       end
     end
 
-    context '`title`が0文字の場合、無効' do
+    context '`title`が0文字の場合' do
       let(:title) { 'A' * 0 }
-      it do
+      it '無効' do
         expect(task).to_not be_valid
         expect(task.errors.full_messages).to match_array("Title can't be blank")
       end
@@ -33,24 +33,24 @@ RSpec.describe Task, type: :model do
   describe '`description`のバリデーションをテスト' do
     let(:task) { build(:task, description: description) }
 
-    context '`description`が1000文字の場合、有効' do
+    context '`description`が1000文字の場合' do
       let(:description) { 'A' * 1000 }
-      it do
+      it '有効' do
         expect(task).to be_valid
       end
     end
 
-    context '`description`が1001文字の場合、無効' do
+    context '`description`が1001文字の場合' do
       let(:description) { 'A' * 1001 }
-      it do
+      it '無効' do
         expect(task).to_not be_valid
         expect(task.errors.full_messages).to match_array('Description is too long (maximum is 1000 characters)')
       end
     end
 
-    context '`description`が0文字の場合、有効' do
+    context '`description`が0文字の場合' do
       let(:description) { 'A' * 0 }
-      it do
+      it '有効' do
         expect(task).to be_valid
       end
     end
@@ -59,24 +59,24 @@ RSpec.describe Task, type: :model do
   describe '`status`のバリデーションをテスト' do
     let(:task) { build(:task, status: status) }
 
-    context '`status`が10文字の場合、有効' do
+    context '`status`が10文字の場合' do
       let(:status) { 'A' * 10 }
-      it do
+      it '有効' do
         expect(task).to be_valid
       end
     end
 
-    context '`status`が11文字の場合、無効' do
+    context '`status`が11文字の場合' do
       let(:status) { 'A' * 11 }
-      it do
+      it '無効' do
         expect(task).to_not be_valid
         expect(task.errors.full_messages).to match_array('Status is too long (maximum is 10 characters)')
       end
     end
 
-    context '`status`が0文字の場合、無効' do
+    context '`status`が0文字の場合' do
       let(:status) { 'A' * 0 }
-      it do
+      it '無効' do
         expect(task).to_not be_valid
         expect(task.errors.full_messages).to match_array("Status can't be blank")
       end
@@ -86,31 +86,26 @@ RSpec.describe Task, type: :model do
   describe '`priority`のバリデーションをテスト' do
     let(:task) { build(:task, priority: priority) }
 
-    context '`priority`が10文字の場合、有効' do
+    context '`priority`が10文字の場合' do
       let(:priority) { 'A' * 10 }
-      it do
+      it '有効' do
         expect(task).to be_valid
       end
     end
 
-    context '`priority`が11文字の場合、無効' do
+    context '`priority`が11文字の場合' do
       let(:priority) { 'A' * 11 }
-      it do
+      it '無効' do
         expect(task).to_not be_valid
         expect(task.errors.full_messages).to match_array('Priority is too long (maximum is 10 characters)')
       end
     end
 
-    context '`priority`が0文字の場合、有効' do
+    context '`priority`が0文字の場合' do
       let(:priority) { 'A' * 0 }
-      it do
+      it '有効' do
         expect(task).to be_valid
       end
     end
-  end
-
-  describe '`deadline`のバリデーションをテスト' do
-    context '`deadline`が`2023-01-01 17:28:00 UT`の場合、有効'
-    context '`deadline`が`2023-01-01 17:28:00 UT`でない場合、無効'
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -57,9 +57,30 @@ RSpec.describe Task, type: :model do
   end
 
   describe '`status`のバリデーションをテスト' do
-    context '`status`が10文字の場合、有効'
-    context '`status`が11文字の場合、無効'
-    context '`status`が0文字の場合、無効'
+    let(:task) { build(:task, status: status) }
+
+    context '`status`が10文字の場合、有効' do
+      let(:status) { 'A' * 10 }
+      it do
+        expect(task).to be_valid
+      end
+    end
+
+    context '`status`が11文字の場合、無効' do
+      let(:status) { 'A' * 11 }
+      it do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array('Status is too long (maximum is 10 characters)')
+      end
+    end
+
+    context '`status`が0文字の場合、有効' do
+      let(:status) { 'A' * 0 }
+      it do
+        expect(task).to_not be_valid
+        expect(task.errors.full_messages).to match_array("Status can't be blank")
+      end
+    end
   end
 
   describe '`priority`のバリデーションをテスト' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -60,18 +60,29 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it '入力必須の確認' do
+      # タイトルの中身を空にする
+      fill_in 'form_title', with: ''
       # タスクの登録ボタン
       click_button 'form_submit'
       # ページが遷移していない事を確認
       expect(page).to have_current_path new_task_path
     end
+
+    it '空白文字の確認' do
+      # タイトルの中身を空白にする
+      fill_in 'form_title', with: ' '
+      # タスクの登録ボタン
+      click_button 'form_submit'
+      # 遷移後のpathを確認
+      expect(page).to have_current_path tasks_path
+      # flashのメッセージを確認
+      expect(page).to have_selector '.alert', text: 'タスクの作成ができませんでした'
+    end
   end
 
   describe '`タスクの詳細`のテスト' do
-    let :task do
-      # 確認用のタスクを作成
-      Task.create(title: '詳細テスト', description: 'タスクの詳細テスト')
-    end
+    # 確認用のタスクを作成
+    let(:task) { Task.create(title: '詳細テスト', description: 'タスクの詳細テスト') }
 
     before do
       # タスクの詳細へ遷移
@@ -96,10 +107,8 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe '`タスクの編集`のテスト' do
-    let :task do
-      # 確認用のタスクを作成
-      Task.create(title: '編集テスト')
-    end
+    # 確認用のタスクを作成
+    let(:task) { Task.create(title: '編集テスト') }
 
     before do
       # タスクの編集へ遷移
@@ -122,13 +131,31 @@ RSpec.describe 'Tasks', type: :system do
       # 値が編集されているか確認
       expect(page).to have_content '編集後のタスク'
     end
+
+    it '入力必須の確認' do
+      # タイトルの中身を空にする
+      fill_in 'form_title', with: ''
+      # タスクの登録ボタン
+      click_button 'form_submit'
+      # ページが遷移していない事を確認
+      expect(page).to have_current_path edit_task_path(task.id)
+    end
+
+    it '空白文字の確認' do
+      # タイトルの中身を空白にする
+      fill_in 'form_title', with: ' '
+      # タスクの登録ボタン
+      click_button 'form_submit'
+      # 遷移後のpathを確認
+      expect(page).to have_current_path task_path(task.id)
+      # flashのメッセージを確認
+      expect(page).to have_selector '.alert', text: 'タスクの更新ができませんでした'
+    end
   end
 
   describe '`タスクの削除`のテスト' do
-    let :task do
-      # 確認用のタスクを作成
-      Task.create(title: '削除テスト')
-    end
+    # 確認用のタスクを作成
+    let(:task) { Task.create(title: '削除テスト') }
 
     before do
       # タスクの詳細へ遷移

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -4,10 +4,15 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
   describe '`タスクの一覧`のテスト' do
+    # 確認用のタスクを作成
+    let(:task1) { create(:task, title: 'タスク1') }
+    let(:task2) { create(:task, title: 'タスク2') }
+
     before do
-      # 確認用のタスクを作成
-      Task.create(title: '一覧テスト1')
-      Task.create(title: '一覧テスト2')
+      # 作成したタスクindexで読み込む
+      task1
+      task2
+
       # タスクの一覧へ遷移
       visit root_path
     end
@@ -17,8 +22,8 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it '全てのタスクが表示されるか確認' do
-      expect(page).to have_content '一覧テスト1'
-      expect(page).to have_content '一覧テスト2'
+      expect(page).to have_content task1.title
+      expect(page).to have_content task2.title
     end
 
     it 'タスクの新規登録へ遷移するか確認' do
@@ -82,7 +87,7 @@ RSpec.describe 'Tasks', type: :system do
 
   describe '`タスクの詳細`のテスト' do
     # 確認用のタスクを作成
-    let(:task) { Task.create(title: '詳細テスト', description: 'タスクの詳細テスト') }
+    let(:task) { create(:task, description: 'タスクの詳細テスト') }
 
     before do
       # タスクの詳細へ遷移
@@ -94,8 +99,8 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     it 'タスクの詳細が表示されるか確認' do
-      expect(page).to have_content '詳細テスト'
-      expect(page).to have_content 'タスクの詳細テスト'
+      expect(page).to have_content task.title
+      expect(page).to have_content task.description
     end
 
     it 'タスクの詳細へ遷移するか確認' do
@@ -108,7 +113,7 @@ RSpec.describe 'Tasks', type: :system do
 
   describe '`タスクの編集`のテスト' do
     # 確認用のタスクを作成
-    let(:task) { Task.create(title: '編集テスト') }
+    let(:task) { create(:task) }
 
     before do
       # タスクの編集へ遷移
@@ -155,7 +160,7 @@ RSpec.describe 'Tasks', type: :system do
 
   describe '`タスクの削除`のテスト' do
     # 確認用のタスクを作成
-    let(:task) { Task.create(title: '削除テスト') }
+    let(:task) { create(:task) }
 
     before do
       # タスクの詳細へ遷移

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -5,14 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Tasks', type: :system do
   describe '`タスクの一覧`のテスト' do
     # 確認用のタスクを作成
-    let(:task1) { create(:task, title: 'タスク1') }
-    let(:task2) { create(:task, title: 'タスク2') }
+    let!(:task1) { create(:task, title: 'タスク1') }
+    let!(:task2) { create(:task, title: 'タスク2') }
 
     before do
-      # 作成したタスクindexで読み込む
-      task1
-      task2
-
       # タスクの一覧へ遷移
       visit root_path
     end


### PR DESCRIPTION
## リンク
- Issue
  - close #26 
- 研修内容
  - [ステップ11: バリデーションを設定してみよう](https://github.com/hiroyasu-shiratori/Fablic-training/tree/master/docs#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%BF%E3%82%88%E3%81%86)
- 参考リンク
  - [【Rails】「テーブルのカラムに定義するNot Null制約」と「モデルに定義するバリデーション（presence: true）」の挙動の違い。 - Qiita](https://qiita.com/wonder_meet/items/fa804f0d436a29c97460)
  - [ActiveRecord でのデフォルト値設定 - Qiita](https://qiita.com/tearoom6/items/15d29b5ce8b3d0c0048c)
  - [【RSpec初級編】FactoryBotを用いてテストコードを効率化する方法について解説｜TechTechMedia](https://techtechmedia.com/factory-bot-rails/)
  - [【rspec】Railsモデルテストの基本 - Qiita](https://qiita.com/AK4747471/items/1b7b4af1e6d102625562)
  - [RailsでのRSpecの設定やら書き方とかいろいろ - Qiita](https://qiita.com/sibakenY/items/2c97e3cfdc54e474c4f2)
  - [ActiveRecordのvalidatesで表示されるエラーメッセージのフォーマットを変更する - Qiita](https://qiita.com/okeicalm/items/9638250ddfb361d80a16)
  - [開発現場で使える！RailsでのValidationの使い方 | TechAcademyマガジン](https://techacademy.jp/magazine/7222)
  - [ActiveRecordのvalidatesで表示されるエラーメッセージのフォーマットを変更する - Qiita](https://qiita.com/okeicalm/items/9638250ddfb361d80a16)

## 内容
- [x] バリデーションを設定しましょう
  - [x] どのカラムにどのバリデーションを追加したらよいか考えてみましょう
  - [x] 合わせてDBの制約も設定するマイグレーションを作成しましょう
  - [x] マイグレーションファイルだけを作成するため、 rails generate コマンドで作成します
- [x] 画面にバリデーションエラーのメッセージを表示するようにしましょう
- [x] バリデーションに対してモデルのテストを書いてみましょう
- [x] GitHub上でPRを作成してレビューしてもらいましょう

## 画面
空文字を入れた際のメッセージ
![image](https://user-images.githubusercontent.com/82800686/119304810-c6257700-bca2-11eb-907e-4bad5866e390.png)

空白文字を入れた際のメッセージ
![image](https://user-images.githubusercontent.com/82800686/119305430-b0648180-bca3-11eb-9a74-4b86ad03cc84.png)
