### PR TITLE
ステップ13: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@
 
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all
+    @search_params = task_search_params
+    @tasks = Task.search(@search_params)
   end
 
   def new
@@ -51,5 +52,9 @@ class TasksController < ApplicationController
 
   def task_params
     params.require(:task).permit(:title, :description, :status, :priority, :deadline)
+  end
+
+  def task_search_params
+    params.fetch(:search, params).permit(:title, :description, :status, :priority, :deadline)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,7 +7,6 @@ class Task < ApplicationRecord
   validates :priority, length: { maximum: 10 }, inclusion: { in: ['高', '中', '低', '', nil] }
 
   scope :search, lambda { |search_params|
-    logger.debug search_params
     return if search_params.blank?
 
     title_like(search_params[:title])

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,4 +5,14 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 1000 }
   validates :status, presence: true, length: { maximum: 10 }, inclusion: { in: %w[未着手 進行中 完了] }
   validates :priority, length: { maximum: 10 }, inclusion: { in: ['高', '中', '低', '', nil] }
+
+  scope :search, lambda { |search_params|
+    logger.debug search_params
+    return if search_params.blank?
+
+    title_like(search_params[:title])
+      .status_is(search_params[:status])
+  }
+  scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") if title.present? }
+  scope :status_is, ->(status) { where(status: status) if status.present? }
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,6 +2,20 @@
 
 <h1>タスクの一覧</h1>
 
+<div>
+  <%= form_with url: tasks_path, method: :get, local: true do |form| %>
+  <p>
+    <%= form.label :title, 'タイトル' %>
+    <%= form.text_field :title, value: @search_params[:title] %>
+  </p>
+  <p>
+    <%= form.label :status, 'ステータス' %>
+    <%= form.select :status, [['未着手', '未着手'], ['進行中', '進行中'], ['完了', '完了']], {prompt: 'タスクの状態'} %>
+    <%= form.submit '検索' %>
+  </p>
+  <% end %>
+</div>
+
 <p><%= button_to '新規登録', {controller: 'tasks', action: 'new'}, {method: :get, id: 'new_button'} %></p>
 
 <table>

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe 'Tasks', type: :system do
   describe '`タスクの一覧`のテスト' do
     # 確認用のタスクを作成
     let!(:task1) { create(:task, title: 'タスク1') }
-    let!(:task2) { create(:task, title: 'タスク2') }
+    let!(:task2) { create(:task, title: 'タスク2', status: '未着手') }
+    let!(:task3) { create(:task, title: 'テスト1', status: '完了') }
+    let!(:task4) { create(:task, title: 'テスト2', status: '未着手') }
 
     before do
       # タスクの一覧へ遷移
@@ -17,16 +19,35 @@ RSpec.describe 'Tasks', type: :system do
       expect(page).to have_title 'タスクの一覧'
     end
 
-    it '全てのタスクが表示されるか確認' do
-      expect(page).to have_content task1.title
-      expect(page).to have_content task2.title
-    end
-
     it 'タスクの新規登録へ遷移するか確認' do
       # タスクの新規登録へ遷移する
       click_button 'new_button'
       # 遷移後のpathを確認
       expect(page).to have_current_path new_task_path
+    end
+
+    context '表示・検索のテスト' do
+      it '絞り込みなしの確認' do
+        expect(page).to have_content task1.title
+        expect(page).to have_content task2.title
+        expect(page).to have_content task3.title
+        expect(page).to have_content task4.title
+      end
+
+      it 'タイトルをタスクで絞り込み' do
+        expect(page).to have_content task1.title
+        expect(page).to have_content task2.title
+      end
+
+      it 'ステータスを未着手で絞り込み' do
+        expect(page).to have_content task2.status
+        expect(page).to have_content task4.status
+      end
+
+      it 'タイトルをタスク、ステータスを未着手で絞り込み' do
+        expect(page).to have_content task2.title
+        expect(page).to have_content task2.status
+      end
     end
   end
 


### PR DESCRIPTION
## リンク
- Issue
  - close #28 
- 研修内容
  - [ステップ13: ステータスを追加して、検索できるようにしよう](https://github.com/hiroyasu-shiratori/Fablic-training/tree/master/docs#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9713-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)
- 参考リンク
  - [【Rails】一覧ページ上部に検索機能を実装する ~ form_with ~ - Qiita](https://qiita.com/shin1rok/items/779e581e9d12a92310c3)
  - [Railsでlogを出力しdebugする - Qiita](https://qiita.com/Kashiwara/items/f8a4030da6b17e96fabf)

## 内容
- [x] ステータス（未着手・着手中・完了）を追加してみよう
  - [x] 【オプション要件】初学者ではない場合はstateを管理するGemを導入しても構いません
- [x] 一覧画面でタイトルとステータスで検索ができるようにしよう
  - [x] 【オプション要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構いません
- [x] 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
  - [x] 以降のステップでも必要に応じて確認する癖をつけましょう
- [x] 検索インデックスを貼りましょう
- [x] 検索に対してmodel specを追加してみよう（system specも拡充しておきましょう）

## SQLのログ
- 絞り込みなし
  ```
   SELECT `tasks`.* FROM `tasks`
  ```
- タイトルをタスクで絞り込み
  ```
  SELECT `tasks`.* FROM `tasks` WHERE (title LIKE '%タスク%')
  ```
- ステータスを未着手で絞り込み
  ```
  SELECT `tasks`.* FROM `tasks` WHERE `tasks`.`status` = '未着手'
  ```
- タイトルをタスク、ステータスを未着手で絞り込み
  ```
  SELECT `tasks`.* FROM `tasks` WHERE (title LIKE '%タスク%') AND `tasks`.`status` = '未着手'
  ```
  
## 画面
- 絞り込みなし
![image](https://user-images.githubusercontent.com/82800686/119624412-16880a80-be44-11eb-9e55-2ead213db86b.png)
- タイトルをタスクで絞り込み
![image](https://user-images.githubusercontent.com/82800686/119624609-4afbc680-be44-11eb-8821-ba54a82408fc.png)
- ステータスを未着手で絞り込み
![image](https://user-images.githubusercontent.com/82800686/119624675-5818b580-be44-11eb-8c3b-dd3880e98a10.png)
- タイトルをタスク、ステータスを未着手で絞り込み
![image](https://user-images.githubusercontent.com/82800686/119624841-85656380-be44-11eb-9761-98fcc1b581f4.png)
